### PR TITLE
Opinions that hottest new crypto trend isn’t great news for the environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # KEEPTHEWORLD
+
+«An explosive new segment of the crypto market has art collectors worldwide reaching for the closest dictionary. Sales of non-fungible tokens (NFTs) exploded in 2020, surpassing $250M, and show no sign of slowing. 
+
+ 
+
+NFTs act as blockchain equivalent of a certificate of authenticity for any piece of digital media imaginable (GIFs, videos, tweets, games, celebrity selfies). They’re particularly popular among art collectors and sports fans looking to build digital collections.
+
+ 
+
+Since its beginning in 2017, the “newest speculative game in town” has provided artists with a new way to support their craft. One artist, who goes by Beeple, made $3.5M by selling 20 pieces in December alone. (Naturally, Christie's auction house wants in on the action.) 
+
+ 
+
+Not unlike the #wallstreetbets/GameStop saga, though, things are getting a little … bananas. Lindsay Lohan sold a photo of herself for $17k — and then juiced the price by tweeting her support for DeFi. People are bidding hundreds of dollars for tweets from Elon Musk and Mark Cuban, who recently declared that the “Store of Value Generation” is here to stay. A clip of LeBron James blocking a shot sold for $100k last month.
+
+ 
+
+Some artists point out that the hottest new crypto trend isn’t such great news for the environment. One calculated that the release of one piece of art with NFT led to more carbon emissions than her entire studio emitted in 18 months.» 
+
+/via anonymous parties/


### PR DESCRIPTION
«{...} Some artists point out that the hottest new crypto trend isn’t such great news for the environment. One calculated that the release of one piece of art with NFT led to more carbon emissions than her entire studio emitted in 18 months.»